### PR TITLE
Add support for fastavro<2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ and can be installed via ``pip`` or ``easy_install``:
 Requirements
 ------------
 - sprockets.mixins.amqp>=3.0.0
-- fastavro>=0.10.1,<1.0.0
+- fastavro>=0.10.1,<2.0.0
 - tornado>=6,<7
 
 Example

--- a/requires/installation.txt
+++ b/requires/installation.txt
@@ -1,4 +1,4 @@
 sprockets.mixins.amqp>=3.0.0,<4
 sprockets.mixins.http>=2.3.0,<3
-fastavro>=0.10.1,<1.0.0
+fastavro>=0.10.1,<2.0.0
 tornado>=6,<7


### PR DESCRIPTION
The breaking change in fastavro 1.0 was that it dropped Python 2 support